### PR TITLE
fix: corrected image paths in Doxygen documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ Makefile
 .clangd
 
 *.tar
+
+html/

--- a/Doxyfile
+++ b/Doxyfile
@@ -1064,7 +1064,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             =
+IMAGE_PATH             = docs
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/docs/game_engine/ecs.md
+++ b/docs/game_engine/ecs.md
@@ -133,5 +133,4 @@ The SystemManager uses these signatures to maintain an up-to-date list of entiti
 Each system processes its specific subset of entities, based on the components they possess.
 
 ### EC Systems UML Diagram
-
-![ECS Systems UML Diagram](ecs_systems_uml.png)
+![ECS Systems UML Diagram](game_engine/ecs_systems_uml.png)

--- a/docs/game_engine/editor.md
+++ b/docs/game_engine/editor.md
@@ -22,9 +22,9 @@ The editor interface is built using ImGui.
 
 It is composed of a menu bar, a scene view, and a hierarchy view.
 
-![Editor Interface](editor_interface.png)
+![Editor Interface](game_engine/editor_interface.png)
 
 ### Editor Windows UML
 
-![Editor Windows UML](editor_windows_uml.png)
+![Editor Windows UML](game_engine/editor_windows_uml.png)
 

--- a/docs/network/README.md
+++ b/docs/network/README.md
@@ -138,4 +138,4 @@ These concepts are foundational to the network architecture of the R-TYPE server
 
 #### Network Implementation UML Diagram
 
-![Network UML](network_uml.png)
+![Network UML](network/network_uml.png)


### PR DESCRIPTION
Description
This PR fixes the image display issue in the Doxygen documentation. The image paths in the markdown files were adjusted to point to the correct locations, and the Doxyfile was updated to include the proper IMAGE_PATH directory.

Main changes:
    Corrected relative paths for images in the documentation.
    Updated the Doxyfile with the appropriate IMAGE_PATH.

Issue fixed:
Fix #30 – Resolved the image display issue in Doxygen-generated documentation.