### PR TITLE
ci(ci/debug): add workflow_dispatch support for debug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build, test and Package
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Enable remote SSH connection. Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
   build:
@@ -41,6 +49,14 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history for all tags and branches (for SonarCloud)
+
+      # DEBUGGING ONLY, to run this trigger with even
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true # Only the person who triggered the workflow can access
+          detached: true # Run in the background and wait for connection
 
       - name: Add Ubuntu toolchain repository
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'}}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to enhance debugging capabilities by enabling optional remote SSH debugging with tmate. The changes allow maintainers to debug workflows interactively when triggered manually.

### Enhancements to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L3-R11): Added a `workflow_dispatch` trigger with an optional `debug_enabled` input, allowing maintainers to enable remote SSH debugging for manual workflow runs.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R53-R60): Integrated the `mxschmitt/action-tmate` action to set up a tmate session for debugging when `debug_enabled` is true. This session is restricted to the workflow trigger actor for security.