### PR TITLE
fix: address switch case fallthrough and improve non-trivial type handling

### DIFF
--- a/editor/src/DocumentWindows/EntityProperties/TypeErasedProperty.cpp
+++ b/editor/src/DocumentWindows/EntityProperties/TypeErasedProperty.cpp
@@ -44,10 +44,13 @@ namespace nexo::editor {
                 break;
             case ecs::FieldType::UInt8:
                 ImGui::InputScalar(field.name.c_str(), ImGuiDataType_U8, data);
+                break;
             case ecs::FieldType::UInt16:
                 ImGui::InputScalar(field.name.c_str(), ImGuiDataType_U16, data);
+                break;
             case ecs::FieldType::UInt32:
                 ImGui::InputScalar(field.name.c_str(), ImGuiDataType_U32, data);
+                break;
             case ecs::FieldType::UInt64:
                 ImGui::InputScalar(field.name.c_str(), ImGuiDataType_U64, data);
                 break;

--- a/editor/src/Editor.cpp
+++ b/editor/src/Editor.cpp
@@ -555,7 +555,6 @@ namespace nexo::editor {
     void Editor::update() const
     {
     	m_windowRegistry.update();
-        Application& app = Application::getInstance();
         getApp().endFrame();
     }
 }

--- a/engine/src/scripting/native/NativeApi.hpp
+++ b/engine/src/scripting/native/NativeApi.hpp
@@ -33,7 +33,7 @@
 #ifdef WIN32 // Set calling convention according to .NET https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportattribute.callingconvention?view=net-9.0#remarks
     #define NEXO_CALL  __stdcall
 #elif defined(__GNUC__) || defined(__clang__)
-    #define NEXO_CALL __attribute__((cdecl))
+    #define NEXO_CALL  // cdecl is the default on Linux/Unix, no need to specify
 #else
     #define NEXO_CALL __cdecl
 #endif


### PR DESCRIPTION
  - Add missing break statements in TypeErasedProperty switch cases for UInt8/16/32
  - Remove unused Application variable in Editor::update()
  - Improve ComponentArray::insert() to handle non-trivially copyable types correctly
    - Use placement new with copy constructor for complex types
    - Keep memcpy optimization for POD types
  - Fix NEXO_CALL macro for Linux/Unix platforms (cdecl is default)