### PR TITLE
feat: add dark mode and title bar name customization

### DIFF
--- a/engine/src/Application.cpp
+++ b/engine/src/Application.cpp
@@ -276,6 +276,7 @@ namespace nexo {
         m_window->init();
         registerWindowCallbacks();
         m_window->setVsync(false);
+        m_window->setDarkMode(true);
 
 #ifdef NX_GRAPHICS_API_OPENGL
         if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress))

--- a/engine/src/renderer/Window.hpp
+++ b/engine/src/renderer/Window.hpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <memory>
 #include <functional>
+#include <utility>
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>
@@ -35,8 +36,9 @@ namespace nexo::renderer {
     {
         unsigned int width;
         unsigned int height;
-        const char *title;
-        bool vsync{};
+        std::string title;
+        bool vsync = true;
+        bool isDarkMode = false;
 
         ResizeCallback resizeCallback;
         CloseCallback closeCallback;
@@ -46,7 +48,7 @@ namespace nexo::renderer {
         MouseMoveCallback mouseMoveCallback;
         FileDropCallback fileDropCallback;
 
-        NxWindowProperty(const unsigned int w, const unsigned h, const char * t) : width(w), height(h), title(t) {}
+        NxWindowProperty(const unsigned int w, const unsigned h, std::string t) : width(w), height(h), title(std::move(t)) {}
     };
 
     /**
@@ -81,6 +83,13 @@ namespace nexo::renderer {
             virtual void getDpiScale(float *x, float *y) const = 0;
 
             virtual void setWindowIcon(const std::filesystem::path& iconPath) = 0;
+
+            virtual void setTitle(const std::string& title) = 0;
+            [[nodiscard]] virtual const std::string& getTitle() const = 0;
+
+            virtual void setDarkMode(bool enabled) = 0;
+            [[nodiscard]] virtual bool isDarkMode() const = 0;
+
             virtual void setVsync(bool enabled) = 0;
             [[nodiscard]] virtual bool isVsync() const = 0;
 

--- a/engine/src/renderer/opengl/OpenGlWindow.cpp
+++ b/engine/src/renderer/opengl/OpenGlWindow.cpp
@@ -20,6 +20,14 @@
 #include "renderer/RendererExceptions.hpp"
 #include "Logger.hpp"
 
+#if defined(_WIN32) || defined(_WIN64)
+    #include <dwmapi.h>
+    #define GLFW_EXPOSE_NATIVE_WIN32
+    #define GLFW_EXPOSE_NATIVE_WGL
+    #define GLFW_NATIVE_INCLUDE_NONE
+    #include <GLFW/glfw3native.h>
+    #pragma comment (lib, "Dwmapi")
+#endif
 
 namespace nexo::renderer {
     static void glfwErrorCallback(const int errorCode, const char *errorStr)
@@ -114,12 +122,13 @@ namespace nexo::renderer {
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-        _openGlWindow = glfwCreateWindow(static_cast<int>(_props.width), static_cast<int>(_props.height), _props.title, nullptr, nullptr);
+        _openGlWindow = glfwCreateWindow(static_cast<int>(_props.width), static_cast<int>(_props.height), _props.title.c_str(), nullptr, nullptr);
         if (!_openGlWindow)
             THROW_EXCEPTION(NxGraphicsApiWindowInitFailure, "OPENGL");
         glfwMakeContextCurrent(_openGlWindow);
         glfwSetWindowUserPointer(_openGlWindow, &_props);
         setVsync(true);
+        setDarkMode(false);
         setupCallback();
         LOG(NEXO_DEV, "Opengl window ({}, {}) initialized", _props.width, _props.height);
     }
@@ -155,15 +164,14 @@ namespace nexo::renderer {
         glfwGetWindowContentScale(_openGlWindow, x, y);
     }
 
-    void NxOpenGlWindow::setWindowIcon(const std::filesystem::path& iconPath)
+    void NxOpenGlWindow::setWindowIcon(const std::filesystem::path &iconPath)
     {
         GLFWimage icon;
         const auto iconStringPath = iconPath.string();
-        icon.pixels = stbi_load(iconStringPath.c_str(), &icon.width, &icon.height, nullptr, 4);
+        icon.pixels               = stbi_load(iconStringPath.c_str(), &icon.width, &icon.height, nullptr, 4);
         if (!icon.pixels) {
             THROW_EXCEPTION(NxStbiLoadException,
-                std::format("Failed to load icon '{}': {}",
-                    iconStringPath, stbi_failure_reason()));
+                            std::format("Failed to load icon '{}': {}", iconStringPath, stbi_failure_reason()));
         }
         if (icon.width == 0 || icon.height == 0) {
             LOG(NEXO_WARN, "Icon '{}' has a size of 0x0", iconStringPath);
@@ -171,6 +179,45 @@ namespace nexo::renderer {
         LOG(NEXO_DEV, "Window icon loaded from '{}', size {}x{}", iconStringPath, icon.width, icon.height);
         glfwSetWindowIcon(_openGlWindow, 1, &icon);
         stbi_image_free(icon.pixels);
+    }
+
+    void NxOpenGlWindow::setTitle(const std::string &title)
+    {
+        _props.title = title;
+        glfwSetWindowTitle(_openGlWindow, _props.title.c_str());
+        LOG(NEXO_DEV, "Window title set to '{}'", _props.title);
+    }
+
+    const std::string &NxOpenGlWindow::getTitle() const
+    {
+        return _props.title;
+    }
+
+    void NxOpenGlWindow::setDarkMode(const bool enabled)
+    {
+#if defined(_WIN32) || defined(_WIN64)
+        HWND hWnd = glfwGetWin32Window(_openGlWindow);
+        if (hWnd == nullptr) {
+            LOG(NEXO_ERROR, "[GLFW ERROR] Failed to get Win32 window handle for dark mode setting");
+            return;
+        }
+
+        const BOOL useDarkMode                 = enabled ? TRUE : FALSE;
+        const BOOL setImmersiveDarkModeSuccess = SUCCEEDED(DwmSetWindowAttribute(
+            hWnd, DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE, &_props.isDarkMode, sizeof(useDarkMode)));
+        if (!setImmersiveDarkModeSuccess) {
+            LOG(NEXO_ERROR, "[GLFW ERROR] Failed to set enable/disable immersive dark mode for window: {}",
+                GetLastError());
+            return;
+        }
+#endif
+        LOG(NEXO_DEV, "Setting dark mode to {}", enabled ? "enabled" : "disabled");
+        _props.isDarkMode = enabled;
+    }
+
+    bool NxOpenGlWindow::isDarkMode() const
+    {
+        return _props.isDarkMode;
     }
 
     void NxOpenGlWindow::setErrorCallback(void *fctPtr)

--- a/engine/src/renderer/opengl/OpenGlWindow.hpp
+++ b/engine/src/renderer/opengl/OpenGlWindow.hpp
@@ -81,6 +81,12 @@ namespace nexo::renderer {
 
             void setWindowIcon(const std::filesystem::path& iconPath) override;
 
+            void setTitle(const std::string& title) override;
+            [[nodiscard]] const std::string& getTitle() const override;
+
+            void setDarkMode(bool enabled) override;
+            [[nodiscard]] bool isDarkMode() const override;
+
             /**
             * @brief Enables or disables vertical synchronization (VSync).
             *


### PR DESCRIPTION
This pull request introduces a new "dark mode" feature for the windowing system and refactors related code for better maintainability. The most important changes include adding support for dark mode, updating window property management, and improving platform-specific functionality for Windows.

### Dark Mode Feature:
* Added `setDarkMode` and `isDarkMode` methods to the `NxWindow` interface and implemented them in `NxOpenGlWindow`. These methods allow toggling and checking the dark mode state. [[1]](diffhunk://#diff-6aa9c7bed1966a4361e002990ab18ed46df76c9203947ef9585e89eeca4d3691R86-R92) [[2]](diffhunk://#diff-3c1a4fcd27d2d6aa984c17fab4ef191a059be8ae20a787e937b984721525f165R184-R222) [[3]](diffhunk://#diff-c46e4326747e212ca20ff622e20045b5ae5ceba80663c7d8e1306500cd568495R84-R89)
* Updated `Application.cpp` to enable dark mode by default when initializing the window.

### Window Property Management:
* Refactored `NxWindowProperty` to use `std::string` for the `title` field instead of a `const char*`, and added a new `isDarkMode` field.
* Updated the constructor of `NxWindowProperty` to use `std::move` for the `title` parameter.

### Platform-Specific Improvements (Windows):
* Added Windows-specific headers and logic to support immersive dark mode using `DwmSetWindowAttribute`. This includes error handling for cases where the window handle cannot be retrieved or the dark mode setting fails. [[1]](diffhunk://#diff-3c1a4fcd27d2d6aa984c17fab4ef191a059be8ae20a787e937b984721525f165R23-R30) [[2]](diffhunk://#diff-3c1a4fcd27d2d6aa984c17fab4ef191a059be8ae20a787e937b984721525f165R184-R222)

### Miscellaneous:
* Updated `glfwCreateWindow` calls to use `std::string::c_str()` for compatibility with the updated `title` field.