### PR TITLE
fix: multi profile on scripting

### DIFF
--- a/engine/src/scripting/managed/CMakeLists.txt
+++ b/engine/src/scripting/managed/CMakeLists.txt
@@ -18,8 +18,6 @@ cmake_minimum_required(VERSION 3.20)
 project(nexoManaged LANGUAGES NONE)
 
 # Define variables for configuration
-set(NEXO_MANAGED_OUTPUT_DIR ${CMAKE_BINARY_DIR})
-file(RELATIVE_PATH NEXO_MANAGED_OUTPUT_DIR_REL "${CMAKE_CURRENT_LIST_DIR}" "${NEXO_MANAGED_OUTPUT_DIR}")
 set(NEXO_FRAMEWORK "net9.0")
 
 set(SOURCES
@@ -63,21 +61,22 @@ else()
 endif()
 
 
-# Build step
+# Build step with OutputPath passed as parameter to support multi-config builds
 add_custom_target(nexoManaged ALL
                   COMMAND ${DOTNET_EXECUTABLE} build Nexo.csproj
                   ${ARCH_ARG}
                   -c $<CONFIG>                        # Matches Debug/Release configuration
+                  /p:OutputPath=${CMAKE_BINARY_DIR}/  # Pass OutputPath dynamically based on build directory
                   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}      # Working directory for the build
-                  COMMENT "Building .NET managed project (Nexo.csproj)..."
+                  COMMENT "Building .NET managed project (Nexo.csproj) for $<CONFIG> configuration..."
 )
 
 # Clean step
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
-    ${NEXO_MANAGED_OUTPUT_DIR}/Nexo.dll
-    ${NEXO_MANAGED_OUTPUT_DIR}/Nexo.pdb
-    ${NEXO_MANAGED_OUTPUT_DIR}/Nexo.runtimeconfig.json
-    ${NEXO_MANAGED_OUTPUT_DIR}/Nexo.deps.json
+    ${CMAKE_BINARY_DIR}/Nexo.dll
+    ${CMAKE_BINARY_DIR}/Nexo.pdb
+    ${CMAKE_BINARY_DIR}/Nexo.runtimeconfig.json
+    ${CMAKE_BINARY_DIR}/Nexo.deps.json
     ${CMAKE_CURRENT_LIST_DIR}/obj
     ${CMAKE_CURRENT_LIST_DIR}/bin
 )

--- a/engine/src/scripting/managed/Nexo.csproj.in
+++ b/engine/src/scripting/managed/Nexo.csproj.in
@@ -8,16 +8,13 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <!-- OutputPath is passed via command line from CMake to support multi-config builds -->
   </PropertyGroup>
 
   <ItemGroup>
 	<Compile Include="@SOURCES@" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <OutputPath>@NEXO_MANAGED_OUTPUT_DIR_REL@</OutputPath>
-  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Solution to #289 
Pass OutputPath dynamically via MSBuild command-line parameter instead of hardcoding it in the .csproj file. This allows each build configuration to output to its correct directory.

### Changes
1. **Nexo.csproj.in**:
   - Removed hardcoded <OutputPath>
   - Moved AppendTargetFrameworkToOutputPath settings to main PropertyGroup

2. **CMakeLists.txt**:
   - Removed NEXO_MANAGED_OUTPUT_DIR_REL variable
   - Added OutputPath=${CMAKE_BINARY_DIR} to dotnet build command
   - Updated ADDITIONAL_CLEAN_FILES to use CMAKE_BINARY_DIR directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Aligned managed build outputs to support multi-configuration builds and standardized cleanup to the new artifact location.
- Refactor
  - Simplified project settings by consolidating output path handling and removing redundant configuration.
- Notes
  - No user-facing features or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->